### PR TITLE
docs: bump vmclarity and remove unused params

### DIFF
--- a/config/_default/config.toml
+++ b/config/_default/config.toml
@@ -74,9 +74,7 @@ twitter = "outshiftbycisco"
   project_name = "OpenClarity"
   product_name = "OpenClarity"
 
-  latest_version = "0.5.0" # Used in some installation commands
-  latest_operator_version = "0.5.0"
-  vmclarity_version = "0.6.0"
+  latest_version = "0.6.0" # Used in some installation commands
 
   ###############################################################################
   # Docsy-theme specific config customizations


### PR DESCRIPTION
* Bump VMClarity release version to 0.6.0
* TBC Remove `latest_operator_version` and `vmclarity_version`