### PR TITLE
docs(aws): add quick-create link

### DIFF
--- a/content/docs/vmclarity/getting-started/deploy-aws/_index.md
+++ b/content/docs/vmclarity/getting-started/deploy-aws/_index.md
@@ -27,7 +27,7 @@ The private subnet (`VmClarityScannerSubnet`) hosts the VM snapshot instances (E
 
 ## Deployment steps
 
-To deploy the VMClarity AWS CloudFormation Stack, complete the following steps.
+To deploy the VMClarity AWS CloudFormation Stack, click [this quick-create link](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=VMClarity&templateURL=https://vmclarity-cfn.s3.eu-central-1.amazonaws.com/0.6.0/VmClarity.cfn) to navigate directly to the AWS CloudFormation console and jump to the wizard instructions or complete the following steps.
 
 1. Download the latest VMClarity release.
 

--- a/content/docs/vmclarity/getting-started/deploy-aws/_index.md
+++ b/content/docs/vmclarity/getting-started/deploy-aws/_index.md
@@ -27,7 +27,10 @@ The private subnet (`VmClarityScannerSubnet`) hosts the VM snapshot instances (E
 
 ## Deployment steps
 
-To deploy the VMClarity AWS CloudFormation Stack, click [this quick-create link](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=VMClarity&templateURL=https://vmclarity-cfn.s3.eu-central-1.amazonaws.com/0.6.0/VmClarity.cfn) to navigate directly to the AWS CloudFormation console and jump to the wizard instructions or complete the following steps.
+To deploy the VMClarity AWS CloudFormation Stack, you can:
+
+- click [this quick-create link](https://console.aws.amazon.com/cloudformation/home#/stacks/create/review?stackName=VMClarity&templateURL=https://vmclarity-cfn.s3.eu-central-1.amazonaws.com/0.6.0/VmClarity.cfn) to navigate directly to the AWS CloudFormation console and jump to the wizard instructions, or 
+- complete the following steps.
 
 1. Download the latest VMClarity release.
 


### PR DESCRIPTION
Change AWS deploy guide to include a quick-create link for stack. Details at https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stacks-quick-create-links.html