### PR TITLE
docs: update Slack registration link in community.md

### DIFF
--- a/content/docs/community.md
+++ b/content/docs/community.md
@@ -5,6 +5,6 @@ weight: 65
 
 If you have questions about the OpenClarity platform or its components, get in touch with us on Slack!
 
-First, [register on the Outshift Slack](https://outshift.com/slack), then [visit our Slack channel](https://outshift.slack.com/messages/openclarity).
+First, [register on the Outshift Slack](https://join.slack.com/t/outshift/shared_invite/zt-26x5d20vn-69Vmo2RoRrqyImSU2wFbPA), then [visit our Slack channel](https://outshift.slack.com/messages/openclarity).
 
 If you'd like to contribute, see our [contribution guidelines]({{< relref "/docs/contributing.md" >}}) for details.


### PR DESCRIPTION
Supposed to fix the limitation users are facing when visiting the old Slack registration link. 